### PR TITLE
Fixed mismapped Shift+0 from . to )

### DIFF
--- a/firmware/badge/hardware/keyboard.py
+++ b/firmware/badge/hardware/keyboard.py
@@ -63,7 +63,7 @@ class Keyboard:
         CTL,  JW,   ALT, "|", " ", None, RIGHT, DOWN, LEFT, ALT,   # 41-50 R4
         None, None, "_", "^", "%", "$",  "}",   "{",  "P",  None,  # 51-60 R5
         None, None, "*", "#", "@", "!",  ENTER, '"',  ":",  None,  # 61-70 R6
-        None, None, "?", "+", ",", ".",  SFT,   UP,   DEL,   None,  # 71-80 R7
+        None, None, "?", "+", ",", ")",  SFT,   UP,   DEL,   None,  # 71-80 R7
     )
     # fmt: on
 


### PR DESCRIPTION
Minor fix. Right now it is impossible to enter the ")" character into the badge. It is physically present on the badge, but it seems to be mapped wrong in software/firmware. This patch is just trying to get the firmware key mapping to reflect the physical labeled on the badge (which presumably is the expected behavior).