### PR TITLE
Fix incorrect command for copying from a folder to the badge

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -281,7 +281,7 @@ There are two methods to copy all the files to the badge.
 `mpremote` will copy everything in the target directory to or from the badge.
 ```bash
 # Copy from computer to badge
-mpremote cp -r badge/ :
+mpremote cp -r badge/* :
 
 # Copy from badge to computer
 mpremote cp -r : badge-backup/


### PR DESCRIPTION
The original instructions caused a new folder `badge` to be created on the badge. This will ensure that the contents of the `badge` folder are copied to the root of the device.