### PR TITLE
Add null check before scrolling page

### DIFF
--- a/firmware/badge/apps/chat.py
+++ b/firmware/badge/apps/chat.py
@@ -233,7 +233,8 @@ class ChatApp(BaseApp):
                 self.topic_picker_active = True
 
         if self.auto_follow:
-            self.page.scroll_bottom()
+            if self.page:
+                self.page.scroll_bottom()
 
         self.refresh_counter = (
             self.refresh_counter + 1


### PR DESCRIPTION
avoid crashing the chat app when page is empty and trying to scroll to the Latest