### PR TITLE
set timestamp on seen messages, fix early expiration bug

### DIFF
--- a/firmware/badge/net/net.py
+++ b/firmware/badge/net/net.py
@@ -114,8 +114,9 @@ class BadgeNet:
                     seen_checksum = struct.unpack(
                         "!H", message.frame[CHECKSUM_OFFSET : CHECKSUM_OFFSET + 2]
                     )[0]
-                    seen_count, seen_timestamp = self.recently_seen_messages.get(seen_checksum, (0, 0))
+                    seen_count, seen_timestamp = self.recently_seen_messages.get(seen_checksum, (0, time.time()))
                     self.recently_seen_messages[seen_checksum] = (seen_count + 1, seen_timestamp)
+                    # print(f"Seen {seen_checksum} @ {seen_timestamp} x {seen_count}")
                     if seen_count == 0:
                         # Check how many times this has been recently seen, and if not, add it to the tx queue
                         retransmit_message = message.check_for_retransmit(MY_ADDRESS)


### PR DESCRIPTION
Default timestamp was never set, causing ALL entries to expire on each call to flush_recently_seen, resulting in dupes being sent to the callbacks