### PR TITLE
fix update script to not break on directory removal

### DIFF
--- a/firmware/scripts/update.py
+++ b/firmware/scripts/update.py
@@ -85,14 +85,15 @@ if __name__ == "__main__":
                 if args.verbose:
                     print(f"{name} is up to date.")
         files_to_delete = set(badge_files.keys()) - set(local_files.keys())
-        for name in files_to_delete:
+        for name in sorted(files_to_delete, reverse=True):
             if name.startswith("/data"):  # Don't delete the data/ directory.
                 continue
             if "__pycache__" in name:  # Don't delete cache files
                 continue
             if badge_files[name] == "":
+                # Can't use rmdir because __pycache__ will linger
                 print(f"Removing directory {name} from badge...")
-                subprocess.run(["mpremote", "rmdir", "-r", name], check=True)
+                subprocess.run(["mpremote", "rm", "-r", name], check=True)
             else:
                 print(f"Deleting {name} from badge...")
                 subprocess.run(["mpremote", "rm", name], check=True)


### PR DESCRIPTION
The sorting ensures files are removed before the directory so it doesn't try to remove an already deleted file.

