### PR TITLE
Fix wrong indentation causing soft locks in talks app

### DIFF
--- a/firmware/badge/apps/talks.py
+++ b/firmware/badge/apps/talks.py
@@ -95,7 +95,7 @@ class Talks(BaseApp):
         if self.badge.keyboard.f3():
             if self.talk_index > 0:
                 self.talk_index = self.talk_index - 1
-            self.talk_changed = True
+                self.talk_changed = True
 
         if self.badge.keyboard.f4():
             if self.talk_index < (num_talks - 1):


### PR DESCRIPTION
My talks app was locking up some amount of the time, and to the best of my knowledge this indentation seems to have fixed it of the things I tried. If it persists it might be something else, but at the very least, looking at the surrounding functions and a brief analysis of things, it seems reasonable that the talk_changed is not in fact true if you press prev/forward when at the end of the list (no change, because no pagination is happening, because there is no page to "turn" to). Open to feedback on this one if I'm misguided somewhere, not as familiar with the talks app yet compared to the others.