### PR TITLE
Added radio parameters to main config files

### DIFF
--- a/firmware/badge/hardware/badge.py
+++ b/firmware/badge/hardware/badge.py
@@ -8,9 +8,7 @@ from hardware.keyboard import Keyboard
 from net.lora import LoraRadio
 from net.crypto import Crypto
 
-
 badge_obj = None  # Singleton reference for use in the python shell for debugging
-
 
 class Badge:
     """Badge object that manages all the badge's hardware and configuration.
@@ -25,36 +23,60 @@ class Badge:
 
         # Load badge config settings
         self.config = Config()
-        if "alias" not in self.config.db.keys():
-            self.config.set("alias", "")
-        if "nametag" not in self.config.db.keys():
-            self.config.set("nametag", "Your Name Here!")
-        # Nametag image settings (defaults): show image on, use a default headshot path
-        if "nametag_show_image" not in self.config.db.keys():
-            self.config.set("nametag_show_image", b'false')
-        if "nametag_image" not in self.config.db.keys():
-            # Store a reasonable default; user can replace this file or change the path
-            self.config.set("nametag_image", b'images/headshots/wrencher.png')
-        if "radio_tx_power" not in self.config.db.keys():
-            self.config.set("radio_tx_power", b'9')
-        if "chat_ttl" not in self.config.db.keys():
-            self.config.set("chat_ttl", b'3')
-        if "send_cooldown_ms" not in self.config.db.keys():
-            self.config.set("send_cooldown_ms", b'1')
+        # Initialize all the default values
+        self._setup_defaults()
 
         print("Initializing badge hardware...")
         # Reserve controller 0 for the SAO header so it never collides with the keyboard bus.
         self.sao_i2c = I2C(0, scl=board.SAO_SCL, sda=board.SAO_SDA, freq=400000)
-        try:
-            tx_power = int(self.config.get("radio_tx_power"))
-        except ValueError:
-            tx_power = 9
-        try:
-            self.send_cooldown_ms = int(self.config.get("send_cooldown_ms"))
-        except ValueError:
-            self.send_cooldown_ms = 1
+
+        # Helper functions to safely decode and parse config values
+        def get_int(key):
+            val = self.config.get(key)
+            if val is None:
+                raise ValueError("Config " + key + " is empty!")
+            if isinstance(val, bytes):
+                val = val.decode()
+            try:
+                return int(val)
+            except ValueError:
+                raise ValueError("Config " + key + " is not a valid int!")
+
+        def get_float(key):
+            val = self.config.get(key)
+            if val is None:
+                raise ValueError("Config " + key + " is empty!")
+            if isinstance(val, bytes):
+                val = val.decode()
+            try:
+                return float(val)
+            except ValueError:
+                raise ValueError("Config " + key + " is not a valid float!")
+
         board.DEBUG_LED.off()  # Default LED off
-        self.lora: LoraRadio = LoraRadio(board.DEBUG_LED, tx_power=tx_power)
+
+        # Setup radio
+        tx_power = get_int("radio_tx_power")
+        frequency = get_float("radio_frequency")
+        bandwidth = get_float("radio_bandwidth")
+        spreading_factor = get_int("radio_spreading_factor")
+        coding_rate = get_int("radio_coding_rate")
+        self.send_cooldown_ms = get_int("send_cooldown_ms")
+
+        print (
+            "Initializing LoRa radio tx power {}, frequency {}, bandwidth {}, SF{}, CR{}."
+            .format(tx_power, frequency, bandwidth, spreading_factor, coding_rate)
+        )
+        self.lora: LoraRadio = LoraRadio(
+            board.DEBUG_LED,
+            tx_power=tx_power,
+            frequency=frequency,
+            bandwidth=bandwidth,
+            spreading_factor=spreading_factor,
+            coding_rate=coding_rate,
+        )
+
+        # Setup Display and Input
         self.display: Display = Display()
         self.display.backlight.duty(500)
         self.keyboard: Keyboard = Keyboard()
@@ -63,6 +85,24 @@ class Badge:
 
         # Create task to run to check hardware, and update singleton reference
         self.task = aio.create_task(self.run())
+
+    def _setup_defaults(self):
+        self._setup_default_config_value("alias", "")
+        self._setup_default_config_value("nametag", "Your Name Here!")
+        self._setup_default_config_value("nametag_show_image", b'false')
+        self._setup_default_config_value("nametag_image", b'images/headshots/wrencher.png')
+        self._setup_default_config_value("radio_tx_power", b'9')
+        self._setup_default_config_value("radio_frequency", b'869.525')
+        self._setup_default_config_value("radio_bandwidth", b'250.0')
+        self._setup_default_config_value("radio_spreading_factor", b'7')
+        self._setup_default_config_value("radio_coding_rate", b'5')
+        self._setup_default_config_value("chat_ttl", b'3')
+        self._setup_default_config_value("send_cooldown_ms", b'1')
+
+    def _setup_default_config_value(self, key, default_value):
+        if key not in self.config.db.keys():
+            print ("Key {} not found, initialized with {}.".format(key, default_value))
+            self.config.set(key, default_value)
 
     async def run(self):
         print("Running badge task...")

--- a/firmware/badge/hardware/badge.py
+++ b/firmware/badge/hardware/badge.py
@@ -30,38 +30,15 @@ class Badge:
         # Reserve controller 0 for the SAO header so it never collides with the keyboard bus.
         self.sao_i2c = I2C(0, scl=board.SAO_SCL, sda=board.SAO_SDA, freq=400000)
 
-        # Helper functions to safely decode and parse config values
-        def get_int(key):
-            val = self.config.get(key)
-            if val is None:
-                raise ValueError("Config " + key + " is empty!")
-            if isinstance(val, bytes):
-                val = val.decode()
-            try:
-                return int(val)
-            except ValueError:
-                raise ValueError("Config " + key + " is not a valid int!")
-
-        def get_float(key):
-            val = self.config.get(key)
-            if val is None:
-                raise ValueError("Config " + key + " is empty!")
-            if isinstance(val, bytes):
-                val = val.decode()
-            try:
-                return float(val)
-            except ValueError:
-                raise ValueError("Config " + key + " is not a valid float!")
-
         board.DEBUG_LED.off()  # Default LED off
 
         # Setup radio
-        tx_power = get_int("radio_tx_power")
-        frequency = get_float("radio_frequency")
-        bandwidth = get_float("radio_bandwidth")
-        spreading_factor = get_int("radio_spreading_factor")
-        coding_rate = get_int("radio_coding_rate")
-        self.send_cooldown_ms = get_int("send_cooldown_ms")
+        tx_power = self.get_int("radio_tx_power")
+        frequency = self.get_float("radio_frequency")
+        bandwidth = self.get_float("radio_bandwidth")
+        spreading_factor = self.get_int("radio_spreading_factor")
+        coding_rate = self.get_int("radio_coding_rate")
+        self.send_cooldown_ms = self.get_int("send_cooldown_ms")
 
         print (
             "Initializing LoRa radio tx power {}, frequency {}, bandwidth {}, SF{}, CR{}."
@@ -91,18 +68,52 @@ class Badge:
         self._setup_default_config_value("nametag", "Your Name Here!")
         self._setup_default_config_value("nametag_show_image", b'false')
         self._setup_default_config_value("nametag_image", b'images/headshots/wrencher.png')
-        self._setup_default_config_value("radio_tx_power", b'9')
-        self._setup_default_config_value("radio_frequency", b'869.525')
-        self._setup_default_config_value("radio_bandwidth", b'250.0')
-        self._setup_default_config_value("radio_spreading_factor", b'7')
-        self._setup_default_config_value("radio_coding_rate", b'5')
-        self._setup_default_config_value("chat_ttl", b'3')
-        self._setup_default_config_value("send_cooldown_ms", b'1')
+        self._setup_default_int("radio_tx_power", b'9')
+        self._setup_default_float("radio_frequency", b'869.525')
+        self._setup_default_float("radio_bandwidth", b'250.0')
+        self._setup_default_int("radio_spreading_factor", b'7')
+        self._setup_default_int("radio_coding_rate", b'5')
+        self._setup_default_int("chat_ttl", b'3')
+        self._setup_default_int("send_cooldown_ms", b'1')
 
     def _setup_default_config_value(self, key, default_value):
         if key not in self.config.db.keys():
             print ("Key {} not found, initialized with {}.".format(key, default_value))
             self.config.set(key, default_value)
+
+    def _setup_default_int(self, key, default_value):
+        self._setup_default_config_value(key, default_value)
+        val = self.config.get(key)
+        if isinstance(val, bytes):
+            val = val.decode()
+        try:
+            int(val)
+        except ValueError:
+            print("Key {} has invalid int {}, reverting to default {}.".format(key, val, default_value))
+            self.config.set(key, default_value)
+
+    def _setup_default_float(self, key, default_value):
+        self._setup_default_config_value(key, default_value)
+        val = self.config.get(key)
+        if isinstance(val, bytes):
+            val = val.decode()
+        try:
+            float(val)
+        except ValueError:
+            print("Key {} has invalid float {}, reverting to default {}.".format(key, val, default_value))
+            self.config.set(key, default_value)
+
+    def get_int(self, key):
+        val = self.config.get(key)
+        if isinstance(val, bytes):
+            val = val.decode()
+        return int(val)
+
+    def get_float(self, key):
+        val = self.config.get(key)
+        if isinstance(val, bytes):
+            val = val.decode()
+        return float(val)
 
     async def run(self):
         print("Running badge task...")

--- a/firmware/badge/net/lora.py
+++ b/firmware/badge/net/lora.py
@@ -10,19 +10,15 @@ from hardware import board
 
 
 class LoraRadio:
-    def __init__(self, tx_led=None, tx_power=9):
+    def __init__(self, tx_led=None, tx_power=9, frequency=869.525, bandwidth=250.0, spreading_factor=7, coding_rate=5):
+        # Defaults are overriten by the ones set on badge.py
         # Settings
         # https://meshtastic.org/docs/overview/radio-settings/
         self.freq_slot = 1
-        self.frequency = 869.525  # MHz: Only one slot in EU
-
-        self.bandwidth = 250.0  # 250000  # kHz: 31000, 125000, or 250000
-        self.coding_rate = (
-            5  # 4/x bit redundancy, increases reliability but decreases datarate: 5 - 8
-        )
-        self.spreading_factor = (
-            7  # 1<<x num chirps per symbol, each step doubles airtime, adds 2.5dB: 7-12
-        )
+        self.frequency = frequency
+        self.bandwidth = bandwidth
+        self.coding_rate = coding_rate  # 4/x bit redundancy, increases reliability but decreases datarate: 5 - 8
+        self.spreading_factor = spreading_factor  # 1<<x num chirps per symbol, each step doubles airtime, adds 2.5dB: 7-12
         self.preamble_length = 16
         self.crc = True
         self.tx_power = tx_power


### PR DESCRIPTION
Created configs for each of the radio parameters
Refactored badge setup for default values

This change should permit users to manually tune the radio more easily without a computer. It also allows for apps that implement meshcore/meshtastic to be set without changing the whole system default.