### PR TITLE
Added screenshot feature!

### DIFF
--- a/firmware/badge/hardware/badge.py
+++ b/firmware/badge/hardware/badge.py
@@ -137,7 +137,7 @@ class Badge:
                 data_size = snapshot.data_size
                 buffer = snapshot.data.__dereference__(data_size)
                 
-                filename = f"/screenshot_{time.ticks_ms()}.raw"
+                filename = f"/data/screenshot_{time.ticks_ms()}.raw"
                 with open(filename, "wb") as f:
                     f.write(buffer)
                 print(f"Screenshot saved to {filename}")

--- a/firmware/badge/hardware/badge.py
+++ b/firmware/badge/hardware/badge.py
@@ -1,4 +1,6 @@
 import asyncio as aio
+import time
+import lvgl
 from machine import I2C
 
 from hardware import board
@@ -57,6 +59,8 @@ class Badge:
         self.display: Display = Display()
         self.display.backlight.duty(500)
         self.keyboard: Keyboard = Keyboard()
+
+        self.keyboard.register_meta_action("p", self.take_screenshot)
 
         self.crypto = Crypto()
 
@@ -123,3 +127,20 @@ class Badge:
 
     def check_background_current_app(self):
         return False
+
+    def take_screenshot(self):
+        try:
+            print("Taking screenshot...")
+            scr = lvgl.screen_active()
+            snapshot = lvgl.snapshot_take(scr, lvgl.COLOR_FORMAT.RGB565)
+            if snapshot:
+                data_size = snapshot.data_size
+                buffer = snapshot.data.__dereference__(data_size)
+                
+                filename = f"/screenshot_{time.ticks_ms()}.raw"
+                with open(filename, "wb") as f:
+                    f.write(buffer)
+                print(f"Screenshot saved to {filename}")
+                snapshot.destroy()
+        except Exception as e:
+            print("Failed to take screenshot:", e)

--- a/firmware/pyproject.toml
+++ b/firmware/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.9"
 dependencies = [
     "esptool>=4.8.1",
     "mpremote>=1.25.0",
+    "Pillow>=12.2.0",
 ]

--- a/firmware/requirements.txt
+++ b/firmware/requirements.txt
@@ -1,2 +1,3 @@
 esptool
 mpremote
+Pillow

--- a/firmware/scripts/convert_screenshot.py
+++ b/firmware/scripts/convert_screenshot.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import sys
+import struct
+import argparse
+from PIL import Image
+
+"""
+Screenshots can be taken on device using the jolly rancher + p key combination.
+Its a bit finicky but it does work. You then copy the raw file out of the device with mpremote and convert it.
+Example:
+    mpremote cp :/screenshot_11658.raw .
+    ./convert_screenshot.py screenshot_11658.raw screenshot_11658.png
+"""
+def convert_rgb565_to_png(input_path, output_path, width=428, height=142, swap=False):
+    with open(input_path, "rb") as f:
+        data = f.read()
+
+    expected_size = width * height * 2
+    if len(data) != expected_size:
+        print(f"Warning: Expected {expected_size} bytes for a {width}x{height} image, but got {len(data)} bytes.")
+
+    img = Image.new("RGB", (width, height))
+    pixels = img.load()
+    
+    idx = 0
+    for y in range(height):
+        for x in range(width):
+            if idx + 2 > len(data):
+                break
+            
+            fmt = ">H" if swap else "<H"
+            pixel = struct.unpack(fmt, data[idx:idx+2])[0]
+            
+            # Extract RGB components from RGB565
+            r = (pixel >> 11) & 0x1F
+            g = (pixel >> 5) & 0x3F
+            b = pixel & 0x1F
+            
+            # Scale up to 0-255
+            r = (r * 255) // 31
+            g = (g * 255) // 63
+            b = (b * 255) // 31
+            
+            pixels[x, y] = (r, g, b)
+            idx += 2
+
+    img.save(output_path)
+    print(f"Successfully converted {input_path} to {output_path}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert an LVGL RGB565 .raw screenshot to .png")
+    parser.add_argument("input", help="Input .raw file from the badge")
+    parser.add_argument("output", help="Output .png file")
+    parser.add_argument("--width", type=int, default=428, help="Width of the screenshot (default: 428)")
+    parser.add_argument("--height", type=int, default=142, help="Height of the screenshot (default: 142)")
+    parser.add_argument("--swap", action="store_true", help="Swap byte order (try this if the colors look mangled)")
+    
+    args = parser.parse_args()
+    
+    try:
+        convert_rgb565_to_png(args.input, args.output, args.width, args.height, args.swap)
+    except Exception as e:
+        print(f"Error converting file: {e}")
+        sys.exit(1)

--- a/firmware/scripts/convert_screenshot.py
+++ b/firmware/scripts/convert_screenshot.py
@@ -8,7 +8,7 @@ from PIL import Image
 Screenshots can be taken on device using the jolly rancher + p key combination.
 Its a bit finicky but it does work. You then copy the raw file out of the device with mpremote and convert it.
 Example:
-    mpremote cp :/screenshot_11658.raw .
+    mpremote cp :/data/screenshot_11658.raw .
     ./convert_screenshot.py screenshot_11658.raw screenshot_11658.png
 """
 def convert_rgb565_to_png(input_path, output_path, width=428, height=142, swap=False):


### PR DESCRIPTION
Now its possible to take a raw screenshot of the screen buffer with the combination meta + p. Meta is the jolly rancher/hackaday logo key.

You then copy the screenshot to your computer with mpremote and use the handy convert script inside scripts/ directory to convert it to png.

<img width="428" height="142" alt="meshcore-dm" src="https://github.com/user-attachments/assets/efd9e9b8-1610-4762-a1e6-a975201130b6" />
