### PR TITLE
Fix: Remove useless scrollbar in the infobar

### DIFF
--- a/firmware/badge/ui/page.py
+++ b/firmware/badge/ui/page.py
@@ -37,6 +37,7 @@ class Page:
         self.infobar.add_style(styles.infobar_style, 0)
         self.infobar.set_width(lvgl.pct(100))
         self.infobar.set_height(INFOBAR_HEIGHT)
+        self.infobar.set_scrollbar_mode(0)
 
         self.infobar_left = lvgl.label(self.infobar)
         self.infobar_left.add_style(styles.infobar_style, 0)


### PR DESCRIPTION
In the chat app, there is a small scrollbar in the infobar (top right of the screen). Its presence is due to the use of the font Montserrat 16, which is 16px high, while the infobar is only 14px high.

The scrollbar can be removed by either : (a) setting the infobar height to a bigger value (with `INFOBAR_HEIGHT = const(16)`) or (b) adding `self.infobar.set_scrollbar_mode(0)`, because for some reason it does not inherit this property from the `flex_container` (but `infobar_right` and `infobar_left` correctly inherit from `infobar`).

I chose the second option in this fix, because it seems more flexible (and it does not modify hardcoded values).